### PR TITLE
Fix URL in README for repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ sudo ldconfig
 Clone git repository:
 
 ```bash
-git clone htpps:/github/aquaticus/nexus433
+git clone https://github.com/aquaticus/nexus433
 cd nexus433
 make
 sudo make install


### PR DESCRIPTION
Fix a couple of typos in the `git clone` command line for cloning the repo in the instructions for building.