### PR TITLE
Fix for wrong temperature values between 0 and -1

### DIFF
--- a/mqttclient.cpp
+++ b/mqttclient.cpp
@@ -84,7 +84,7 @@ void MQTTClient::SensorUpdate(uint16_t id, const Packet& packet)
     Substitute(id);
 
     const char* payload_fmt = "{ "
-            "\"temperature\": %d.%u, "
+            "\"temperature\": %.1f, "
             "\"humidity\": %d, "
             "\"battery\": \"%s\", "
             "\"quality\": %d "
@@ -94,7 +94,6 @@ void MQTTClient::SensorUpdate(uint16_t id, const Packet& packet)
     snprintf(payload, sizeof(payload),
             payload_fmt,
             packet.GetTemperature(),
-            packet.GetTemperatureFraction(),
             packet.GetHumidity(),
             packet.GetBattery() ? Config::transmitter::battery_normal.c_str() : Config::transmitter::battery_low.c_str(),
             packet.GetQualityPercent()

--- a/packet.h
+++ b/packet.h
@@ -79,9 +79,9 @@ public:
   }
 
   // Returns integer part of temperature, e.g. for -10.7 returns -10
-  int16_t GetTemperature() const
+  double GetTemperature() const
   {
-    return GetTemperature10() / 10;
+    return GetTemperature10() / 10.0;
   }
 
   uint8_t GetHumidity() const


### PR DESCRIPTION
The patch changes the temperature type to double and allows correct readings for the range between 0 and -1 degrees.