### PR TITLE
linking objects in required order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRC=$(wildcard *.cpp)
 OBJ=$(SRC:%.cpp=%.o)
 
 all: $(OBJ)
-	$(CXX) $(LIBS) -o $(BIN) $^
+	$(CXX) $^ $(LIBS) -o $(BIN)
 
 clean:
 	rm -f *.o

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Modified version for Digoo H8S remote sensor with LCD display
+
 ![logo](pics/logo.png)
 
 # Introduction

--- a/decoder.cpp
+++ b/decoder.cpp
@@ -25,13 +25,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define LENGTH(x, len) (x<len+m_ToleranceUs && x>len-m_ToleranceUs)
 
 // microseconds
-#define PULSE_HIGH_LEN 500
-#define PULSE_LOW_ZERO 1000
-#define PULSE_LOW_ONE 2000
-#define SYNC_GAP_LEN 4000
+#define PULSE_HIGH_LEN 600
+#define PULSE_LOW_ZERO 2000
+#define PULSE_LOW_ONE 4000
+#define SYNC_GAP_LEN 9000
 
-// Packet consist of 36 bits
-#define PACKET_BITS_COUNT 36
+// Packet consist of 37 bits
+#define PACKET_BITS_COUNT 37
 
 void Decoder::Start()
 {

--- a/packet.h
+++ b/packet.h
@@ -24,8 +24,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /*
 * the data is grouped in 9 nibbles
-* [0x9(4)] [id(8)] [lowBatt(1)] [test(1)] [channel(2)] [temp(12)] [0x0(1)] [humi(7)] [0x0(1)]
+* [0xfixid(4)] [id(8)] [lowBatt(1)] [test(1)] [channel(2)] [temp(12)] [0x0(1)] [humi(7)] [0x0(1)]
 *
+* fixid: fixed part of id?, does not changes with battery replacement, second sensor has different value
 * The 8-bit id changes when the battery is changed in the sensor.
 * test button pressed
 * channel: 0=CH1, 1=CH2, 2=CH3

--- a/packet.h
+++ b/packet.h
@@ -55,6 +55,11 @@ public:
     return GetId() << 8 | GetChannel();
   }
 
+  uint8_t GetSensorType() const
+  {
+    return (m_Raw >> 33) & 0x0F;
+  }
+  
   uint8_t GetId() const
   {
     return (m_Raw >> 25) & 0xFF;
@@ -134,7 +139,9 @@ public:
 
   uint8_t GetQualityPercent() const
   {
-      return ((m_FrameCounter * 100) / 7);
+      int expectedCount = 7; //sensorType==9
+      if(GetSensorType() == 4) expectedCount = 1;
+      return ((m_FrameCounter * 100) / expectedCount);
   }
 
   void Substitute(uint16_t newId)


### PR DESCRIPTION
libraries need to be listed first, to resolve 'undefined reference to' errors