### PR TITLE
version.cmake: quote ${GIT_VERSION} to pass build

### DIFF
--- a/version.cmake
+++ b/version.cmake
@@ -21,7 +21,7 @@ message(STATUS "Software version: ${VERSION}")
 configure_file(${SRC} ${DST} @ONLY)
 
 # no easy way to pass version to CPack, separate script is used to build package
-string(REGEX REPLACE "^v"  "" PACKAGE_VERSION ${GIT_VERSION} )
+string(REGEX REPLACE "^v"  "" PACKAGE_VERSION "${GIT_VERSION}" )
 set(PACKAGE_VERSION_BOARD "${PACKAGE_VERSION}-${BOARD}")
 configure_file(${PKG_SRC} ${PKG_DST} @ONLY)
 execute_process(COMMAND "chmod" "+x" ${PKG_DST})


### PR DESCRIPTION
If GIT_VERSION is undefined, e.g., for a build where the version was not determined using git, PACKAGE_VERSION is "unknown", not quoting ${GIT_VERSION} lets cmake not see that argument at all, which then refuses to work with ```string sub-command REGEX, mode REPLACE needs at least 6 arguments total to command.``` (it sees only 5). Quoting the (maybe empty) string lets cmake see the argument, even if it is an empty string.