### PR TITLE
Reduce CPU usage with a decoder that works using gpiod events.

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -39,6 +39,7 @@ std::string Config::mqtt::certfile;
 std::string Config::mqtt::keyfile;
 std::string Config::mqtt::keypass;
 
+int Config::receiver::polling = 0;
 string Config::receiver::chip = GPIOD_DEFAULT_DEVICE;
 int Config::receiver::pin = GPIOD_DEFAULT_PIN;
 int Config::receiver::resolution_us = 1;
@@ -83,6 +84,7 @@ bool Config::Load(const char *filename)
   Config::mqtt::keyfile = ini.Get("mqtt", "keyfile", "");
   Config::mqtt::keypass = ini.Get("mqtt", "keypass", "");
 
+  Config::receiver::polling = ini.GetInteger("receiver", "polling", Config::receiver::polling);
   Config::receiver::chip = ini.Get("receiver", "chip", Config::receiver::chip);
   Config::receiver::pin = ini.GetInteger("receiver", "pin", Config::receiver::pin);
   Config::receiver::resolution_us = ini.GetInteger("receiver", "resolution_us", Config::receiver::resolution_us);

--- a/config.h
+++ b/config.h
@@ -47,6 +47,7 @@ public:
 
   struct receiver
   {
+    static int polling;
     static std::string chip;
     static int pin;
     static int resolution_us;

--- a/decoder.h
+++ b/decoder.h
@@ -37,11 +37,12 @@ public:
 		STATE_PULSE_END,
 	} STATES;
 
-	Decoder(IStorage& s, gpiod_line *line, int tolerance, int precision):
+	Decoder(IStorage& s, gpiod_line *line, int tolerance, int precision, int polling):
 	m_Storage(s),
     m_Line(line),
 	m_ToleranceUs(tolerance),
-	m_ResolutionUs(precision)
+	m_ResolutionUs(precision),
+	m_Polling(polling)
 	{
 		m_pThread = NULL;
 		m_ErrorStop = false;
@@ -67,6 +68,8 @@ public:
 
 protected:
 	void ThreadFunc();
+	void PollingReader();
+	void EventReader();
 	void Decode(bool risingEdge, long long delta);
 
 	IStorage& m_Storage;
@@ -79,6 +82,7 @@ protected:
 	gpiod_line* m_Line;
 	int m_ToleranceUs; // +/- tolerance in microseconds, default 150
 	int m_ResolutionUs; // how long go to sleep in microseconds. Lower number (0 best) better precision but higher system load
+	int m_Polling; // 1 to use polling, 0 to use events
 	std::atomic<bool> m_ErrorStop;
 	std::future<void> m_Future;
 };

--- a/main.cpp
+++ b/main.cpp
@@ -355,13 +355,29 @@ int main(int argc, char** argv)
         return -2;
     }
 
-    rv = gpiod_line_request_input(line, NEXUS433);
-    if (-1 == rv)
+    if (1 == Config::receiver::polling)
     {
-        gpiod_line_release(line);
-        gpiod_chip_close(chip);
-        std::cerr << "Request for line input failed." << std::endl;
-        return -3;
+        std::cout << "Decoding using polling" << std::endl;
+        rv = gpiod_line_request_input(line, NEXUS433);
+        if (-1 == rv)
+        {
+            gpiod_line_release(line);
+            gpiod_chip_close(chip);
+            std::cerr << "Request for line input failed." << std::endl;
+            return -3;
+        }
+    }
+    else
+    {
+        std::cout << "Decoding using events" << std::endl;
+        rv = gpiod_line_request_both_edges_events(line, NEXUS433);
+        if (-1 == rv)
+        {
+            gpiod_line_release(line);
+            gpiod_chip_close(chip);
+            std::cerr << "Request for line events failed." << std::endl;
+            return -3;
+        }
     }
 
     Led led;
@@ -391,7 +407,7 @@ int main(int argc, char** argv)
         return -7;
     }
 
-    Decoder decoder(storage, line, Config::receiver::tolerance_us, Config::receiver::resolution_us);
+    Decoder decoder(storage, line, Config::receiver::tolerance_us, Config::receiver::resolution_us, Config::receiver::polling);
 
     g_pDecoder = &decoder;
     std::signal(SIGINT, terminate_handler);

--- a/nexus433.ini.in
+++ b/nexus433.ini.in
@@ -36,6 +36,8 @@
 ;tolerance_us=300
 ; internal led device located in /sys/class/leds
 ; internal_led=""
+; use polling mode - avoids using gpiod events and uses more CPU
+;polling=0
 
 [transmitter]
 ; timeout in seconds. If transmitter does not send any data within that period it's reported as offline


### PR DESCRIPTION
Gpiod library also supports receiving events on rising or falling edge for a given pin. This change adds support for this and makes it default, since it uses less CPU.

The old polling mode can still be enabled by adding the following configuration to the config file:

[receiver]
polling=1

Resource usage is significantly lower - on Raspberry Pi 2 the CPU usage goes from 40+% to around 1%-2% user space and 1%-2% kernel IRQ that handles the events, somewhat depending on how noisy the frequency is.

I have not noticed any adverse side effects using this.